### PR TITLE
Add missing single quote in the parameter for the Go cache template

### DIFF
--- a/step-setup-go-cache.yml
+++ b/step-setup-go-cache.yml
@@ -9,7 +9,7 @@
 # Parameters:
 # path: path to pkg/mod to cache (example $(GOPATH)/pkg/mod)
 parameters:
-  path: $(GOPATH)/pkg/mod'
+  path: '$(GOPATH)/pkg/mod'
 
 steps:
 - script: |


### PR DESCRIPTION
Signed-off-by: Krzysztof Wilczyński <krzysztof.wilczynski@nordcloud.com>