### PR TITLE
Update tag validity regex to handle monorepo

### DIFF
--- a/step-set-tag-output.yml
+++ b/step-set-tag-output.yml
@@ -31,7 +31,7 @@
 parameters:
   - name: 'validationRegexp'
     type: 'string'
-    default: '^v[0-9]+(.[0-9]+){1,3}$'
+    default: 'v[0-9]+(.[0-9]+){1,3}$'
   - name: 'failOnNotFound'
     type: 'boolean'
     default: false


### PR DESCRIPTION
Golang's monorepo requires using tags that do not conform to the defined regex, as they always start with module name, e.g.: `cloudwaste/v1.2.3`. This change will make so that a valid tag does not have to start with the `v1.2.3`, just end with it.