### PR TITLE
[KLAR-7754] Implement Azure DevOps pipeline JFrog template for NPM projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Documentation can be found in Microsoft pages: https://docs.microsoft.com/en-us/
 * `step-set-tag-output` - git tag helper validation.
 * `step-trigger-amplify-console-build` - triggers Amplify pipeline build so that you have visbility in your Azure pipelines
 * `job-trigger-pipeline-multiple-times` - A pipeline that triggers a secondary pipeline an x amount of times. Used in a project previously to trigger a Virtual Machine creation pipeline with identical parameters.
+* `step-setup-npm-jfrog-proxy.yml` - set NPM settings (.npmrc) to work with JFrog Artifactory
 
 
 ## Usage example

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -10,9 +10,6 @@
 # jf_access_token: JFrog access token
 # work_dir: pipeline stage working direcorty where .npmrc is created
 
-# JFrog NMP usage documentation:
-# https://nordcloud.atlassian.net/wiki/spaces/RND/pages/4123492446/NPM+local+environment+configuration+for+JFrog+NPM+proxy
-
 # Example usage
 # steps:
 #   - task: NodeTool@0

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -20,13 +20,11 @@ parameters:
 steps:
   - script: |
       pwd
-      echo "HOME: $HOME"
-      echo "./$(ROOT_DIR)"
       echo "Creating ~/.npmrc"
-      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ./$(ROOT_DIR)/.npmrc
-      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ./$(ROOT_DIR)/.npmrc
-      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> ./$(ROOT_DIR)/.npmrc
-      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> ./$(ROOT_DIR)/.npmrc
+      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
+      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc
+      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc
+      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> .npmrc
       echo "email = pat-devops@nordcloud.com" >> ./$(ROOT_DIR)/.npmrc
       cat ./$(ROOT_DIR)/.npmrc
     displayName: "Configure JFrog proxy for NPM"

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -25,7 +25,7 @@ steps:
       echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc
       echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc
       curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> .npmrc
-      echo "email = pat-devops@nordcloud.com" >> ./$(ROOT_DIR)/.npmrc
-      cat ./$(ROOT_DIR)/.npmrc
+      echo "email = pat-devops@nordcloud.com" >> .npmrc
+      cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
     workingDirectory: ./$(ROOT_DIR)

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -9,7 +9,7 @@
 
 parameters:
 - name: jf_server_id 
-  default: 
+  default: nordcloud.jfrog.io
 - name: jf_npm_repo 
   default: npm-virtual
 - name: jf_user 

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -20,12 +20,12 @@ parameters:
 steps:
   - script: |
       pwd
-      echo "Creating ~/.npmrc"
-      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
-      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc
-      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc
-      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> .npmrc
-      echo "email = pat-devops@nordcloud.com" >> .npmrc
-      cat .npmrc
+      echo "Creating $HOME/.npmrc"
+      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > $HOME/.npmrc
+      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> $HOME/.npmrc
+      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> $HOME/.npmrc
+      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> $HOME/.npmrc
+      echo "email = pat-devops@nordcloud.com" >> $HOME/.npmrc
+      cat $HOME/.npmrc
     displayName: "Configure JFrog proxy for NPM"
     workingDirectory: ./$(ROOT_DIR)

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -16,16 +16,18 @@ parameters:
   default: pat-devops
 - name: jf_access_token 
   default: 
+- name: work_dir 
+  default: 
 
 steps:
   - script: |
       pwd
-      echo "Creating $HOME/.npmrc"
-      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > $HOME/.npmrc
-      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> $HOME/.npmrc
-      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> $HOME/.npmrc
-      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> $HOME/.npmrc
-      echo "email = pat-devops@nordcloud.com" >> $HOME/.npmrc
-      cat $HOME/.npmrc
+      echo "Creating .npmrc"
+      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
+      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc
+      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc
+      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> .npmrc
+      echo "email = pat-devops@nordcloud.com" >> .npmrc
+      cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
-    workingDirectory: $HOME
+    workingDirectory: ${{work_dir}}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -19,11 +19,15 @@ parameters:
 
 steps:
   - script: |
+      pwd
+      echo "HOME: $HOME"
+      echo "./$(ROOT_DIR)"
       echo "Creating ~/.npmrc"
-      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ~/.npmrc
-      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ~/.npmrc
-      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> ~/.npmrc
-      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> ~/.npmrc
-      echo "email = pat-devops@nordcloud.com" >> ~/.npmrc
-      cat ~/.npmrc
+      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ./$(ROOT_DIR)/.npmrc
+      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ./$(ROOT_DIR)/.npmrc
+      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> ./$(ROOT_DIR)/.npmrc
+      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> ./$(ROOT_DIR)/.npmrc
+      echo "email = pat-devops@nordcloud.com" >> ./$(ROOT_DIR)/.npmrc
+      cat ./$(ROOT_DIR)/.npmrc
     displayName: "Configure JFrog proxy for NPM"
+    workingDirectory: ./$(ROOT_DIR)

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -21,6 +21,7 @@ parameters:
 
 steps:
   - script: |
+      cd ${{ work_dir }}
       pwd
       echo "Creating .npmrc"
       echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
@@ -30,4 +31,3 @@ steps:
       echo "email = pat-devops@nordcloud.com" >> .npmrc
       cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
-    workingDirectory: ${{ work_dir }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -39,7 +39,7 @@ parameters:
 
 steps:
   - script: |
-      echo "Creating .npmrc"
+      echo "Creating .npmrc pointing to JFrog Artifactory"
       echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
       echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc
       echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -30,4 +30,4 @@ steps:
       echo "email = pat-devops@nordcloud.com" >> .npmrc
       cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
-    workingDirectory: ${{work_dir}}
+    workingDirectory: ${{ work_dir }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -25,8 +25,8 @@ steps:
       installCustomVersion: true
       cliVersion: ${{ parameters.jf_cli_version }}
   - script: |
-      export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
-      ls -lartR /opt/hostedtoolcache/jf/
+      export PATH=$PATH:/__t/jf/${{ parameters.jf_cli_version }}/x64/
+      ls -lartR /__t/jf/
       echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
       jf --version
       jf c add ${{ parameters.jf_server_id }} --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -1,5 +1,7 @@
+# Copyright 2021-2022 Nordcloud Oy or its affiliates. All Rights Reserved.
+
 # Version 1.0.0
-# Maintainer: Tadas Kazlauskas
+# Maintainer: Tadas Kazlauskas at tadas.kazlauskas@nordcloud.com
 
 # Parameters:
 # jf_server_id: JFrog server id (default: nordcloud.jfrog.io)

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -10,6 +10,9 @@
 # jf_access_token: JFrog access token
 # work_dir: pipeline stage working direcorty where .npmrc is created
 
+# JFrog NMP usage documentation:
+# https://nordcloud.atlassian.net/wiki/spaces/RND/pages/4123492446/NPM+local+environment+configuration+for+JFrog+NPM+proxy
+
 # Example usage
 # steps:
 #   - task: NodeTool@0

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -9,28 +9,21 @@
 
 parameters:
 - name: jf_server_id 
-  default: ''
+  default: 
 - name: jf_npm_repo 
   default: npm-virtual
+- name: jf_user 
+  default: pat-devops
 - name: jf_access_token 
-  default: ''
-- name: jf_cli_version 
-  default: 2.28.1
+  default: 
 
 steps:
-  - task: JFrogToolsInstaller@1
-    inputs:
-      artifactoryConnection: "JFrog Artifactory V2"
-      cliInstallationRepo: "jfrog-cli"
-      installCustomVersion: true
-      cliVersion: ${{ parameters.jf_cli_version }}
   - script: |
-      export PATH=$PATH:/__t/jf/${{ parameters.jf_cli_version }}/x64/
-      ls -lartR /__t/jf/
-      echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
-      jf --version
-      jf c add ${{ parameters.jf_server_id }} --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}
-      jf npm-config --repo-resolve ${{ parameters.jf_npm_repo }} --server-id-resolve ${{ parameters.jf_server_id }}
-      jf rt ping
-      jf c show
+      echo "Creating ~/.npmrc"
+      echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ~/.npmrc
+      echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> ~/.npmrc
+      echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> ~/.npmrc
+      curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> ~/.npmrc
+      echo "email = pat-devops@nordcloud.com" >> ~/.npmrc
+      cat ~/.npmrc
     displayName: "Configure JFrog proxy for NPM"

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -15,7 +15,7 @@ parameters:
 - name: jf_access_token 
   default: ''
 - name: jf_cli_version 
-  default: '2.28.1'
+  default: 2.28.1
 
 steps:
   - task: JFrogToolsInstaller@1
@@ -27,7 +27,7 @@ steps:
   - script: |
       export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
       echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
-      echo 'jf test'
+      jf --version
       jf c add ${{ parameters.jf_server_id }} --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}
       jf npm-config --repo-resolve ${{ parameters.jf_npm_repo }} --server-id-resolve ${{ parameters.jf_server_id }}
       jf rt ping

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -26,6 +26,7 @@ steps:
       cliVersion: ${{ parameters.jf_cli_version }}
   - script: |
       export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
+      ls -lartR /opt/hostedtoolcache/jf/
       echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
       jf --version
       jf c add ${{ parameters.jf_server_id }} --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -11,11 +11,11 @@ parameters:
 - name: jf_server_id 
   default: ''
 - name: jf_npm_repo 
-  default: ''
+  default: 'npm-virtual'
 - name: jf_access_token 
   default: ''
 - name: jf_cli_version 
-  default: ''
+  default: '2.28.1'
 
 steps:
   - task: JFrogToolsInstaller@1
@@ -28,7 +28,7 @@ steps:
       export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
       echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
       echo 'jf test'
-      jf c add $(JF_SERVER_ID) --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=$(JF_ACCESS_TOKEN)
+      jf c add $(JF_SERVER_ID) --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}
       jf npm-config --repo-resolve ${{ parameters.jf_npm_repo }} --server-id-resolve ${{ parameters.jf_server_id }}
       jf rt ping
       jf c show

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -11,7 +11,7 @@ parameters:
 - name: jf_server_id 
   default: ''
 - name: jf_npm_repo 
-  default: 'npm-virtual'
+  default: npm-virtual
 - name: jf_access_token 
   default: ''
 - name: jf_cli_version 

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -28,7 +28,7 @@ steps:
       export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
       echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
       echo 'jf test'
-      jf c add $(JF_SERVER_ID) --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}
+      jf c add ${{ parameters.jf_server_id }} --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=${{ parameters.jf_access_token }}
       jf npm-config --repo-resolve ${{ parameters.jf_npm_repo }} --server-id-resolve ${{ parameters.jf_server_id }}
       jf rt ping
       jf c show

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -1,27 +1,42 @@
 # Version 1.0.0
 # Maintainer: Tadas Kazlauskas
-# You need your global variables set anyways
+
 # Parameters:
-# JF_SERVER_ID: JFrog server id (default: nordcloud.jfrog.io)
-# JF_ACCESS_TOKEN: JFrog access token
-# JF_NPM_REPO: JFrog virtual repository name
-# JFROG_CLI_VERSION: JFrog CLI version
+# jf_server_id: JFrog server id (default: nordcloud.jfrog.io)
+# jf_npm_repo: JFrog access token (default: npm-virtual)
+# jf_user: JFrog user used to access artifactory (default: pat-devops)
+# jf_access_token: JFrog access token
+# work_dir: pipeline stage working direcorty where .npmrc is created
+
+# Example usage
+# steps:
+#   - task: NodeTool@0
+#     inputs:
+#       versionSpec: $(NODE_VERSION)
+#   - template: step-setup-npm-jfrog-proxy.yml@nordcloud-templates
+#     parameters:
+#       jf_access_token: $(JF_ACCESS_TOKEN)
+#       work_dir: ./$(ROOT_DIR)
 
 parameters:
-- name: jf_server_id 
-  default: nordcloud.jfrog.io
-- name: jf_npm_repo 
-  default: npm-virtual
-- name: jf_user 
-  default: pat-devops
-- name: jf_access_token 
+- name: 'jf_server_id'
+  type: 'string'
+  default: 'nordcloud.jfrog.io'
+- name: 'jf_npm_repo'
+  type: 'string'
+  default: 'npm-virtual'
+- name: 'jf_user'
+  type: 'string'
+  default: 'pat-devops'
+- name: 'jf_access_token'
+  type: 'string'
   default: 
-- name: work_dir 
+- name: 'work_dir'
+  type: 'string'
   default: 
 
 steps:
   - script: |
-      pwd
       echo "Creating .npmrc"
       echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
       echo "@nordcloud:registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" >> .npmrc

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -21,7 +21,6 @@ parameters:
 
 steps:
   - script: |
-      cd ${{ work_dir }}
       pwd
       echo "Creating .npmrc"
       echo "registry=https://${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/" > .npmrc
@@ -31,3 +30,4 @@ steps:
       echo "email = pat-devops@nordcloud.com" >> .npmrc
       cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
+    workingDirectory: ${{ parameters.work_dir }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -28,6 +28,5 @@ steps:
       echo -n "//${{ parameters.jf_server_id }}/artifactory/api/npm/${{ parameters.jf_npm_repo }}/:" >> .npmrc
       curl -u${{ parameters.jf_user }}:${{ parameters.jf_access_token }} https://${{ parameters.jf_server_id }}/artifactory/api/npm/auth >> .npmrc
       echo "email = pat-devops@nordcloud.com" >> .npmrc
-      cat .npmrc
     displayName: "Configure JFrog proxy for NPM"
     workingDirectory: ${{ parameters.work_dir }}

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -1,0 +1,35 @@
+# Version 1.0.0
+# Maintainer: Tadas Kazlauskas
+# You need your global variables set anyways
+# Parameters:
+# JF_SERVER_ID: JFrog server id (default: nordcloud.jfrog.io)
+# JF_ACCESS_TOKEN: JFrog access token
+# JF_NPM_REPO: JFrog virtual repository name
+# JFROG_CLI_VERSION: JFrog CLI version
+
+parameters:
+- name: jf_server_id 
+  default: ''
+- name: jf_npm_repo 
+  default: ''
+- name: jf_access_token 
+  default: ''
+- name: jf_cli_version 
+  default: ''
+
+steps:
+  - task: JFrogToolsInstaller@1
+    inputs:
+      artifactoryConnection: "JFrog Artifactory V2"
+      cliInstallationRepo: "jfrog-cli"
+      installCustomVersion: true
+      cliVersion: ${{ parameters.jf_cli_version }}
+  - script: |
+      export PATH=$PATH:/opt/hostedtoolcache/jf/${{ parameters.jf_cli_version }}/x64/
+      echo 'JF_SERVER_ID: ${{ parameters.jf_server_id }}'
+      echo 'jf test'
+      jf c add $(JF_SERVER_ID) --url=https://${{ parameters.jf_server_id }}/ --interactive=false --access-token=$(JF_ACCESS_TOKEN)
+      jf npm-config --repo-resolve ${{ parameters.jf_npm_repo }} --server-id-resolve ${{ parameters.jf_server_id }}
+      jf rt ping
+      jf c show
+    displayName: "Configure JFrog proxy for NPM"

--- a/step-setup-npm-jfrog-proxy.yml
+++ b/step-setup-npm-jfrog-proxy.yml
@@ -28,4 +28,4 @@ steps:
       echo "email = pat-devops@nordcloud.com" >> $HOME/.npmrc
       cat $HOME/.npmrc
     displayName: "Configure JFrog proxy for NPM"
-    workingDirectory: ./$(ROOT_DIR)
+    workingDirectory: $HOME


### PR DESCRIPTION
Implemented JFrog Artifactory template for NPM projects allows NPM to be configured to use JFrog Artifactory as a proxy.
Template creates .npmrc file with JFrog Artifactory specific info what later is used by NPM CLI.

Template usage documentation is available at:
https://nordcloud.atlassian.net/wiki/spaces/RND/pages/4123492446/NPM+local+environment+configuration+for+JFrog+NPM+proxy